### PR TITLE
mount ephemeral storage as Z:

### DIFF
--- a/cloudygamer.psm1
+++ b/cloudygamer.psm1
@@ -141,10 +141,26 @@ workflow Install-CloudyGamer {
     if ($Using:IsAWS) {
       Remove-Item "$home\Desktop\EC2 Feedback.website" -ErrorAction SilentlyContinue
       Remove-Item "$home\Desktop\EC2 Microsoft Windows Guide.website" -ErrorAction SilentlyContinue
+    }
 
-      # provision ephemeral storage as Z:
-      '{ "driveLetterMapping": [ { "volumeName": "Temporary Storage 0", "driveLetter": "Z" } ] }' > c:\ProgramData\Amazon\EC2-Windows\Launch\Config\DriveLetterMappingConfig.json
-      c:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeDisks.ps1 -Schedule
+    # provision ephemeral storage as Z:
+    if ($Using:IsAWS) {
+        Set-Variable ec2LaunchPath -Option Constant -Scope Local -Value (Join-Path $env:ProgramData -ChildPath "Amazon\EC2-Windows\Launch")
+        Set-Variable scriptPath -Option Constant -Scope Local -Value (Join-Path $ec2LaunchPath -ChildPath "Scripts\InitializeDisks.ps1")
+
+        if ($scriptPath) {
+          # Configure drive letter mapping
+          Set-Variable configPath -Option Constant -Scope Local -Value (Join-Path $ec2LaunchPath -ChildPath "Config\DriveLetterMappingConfig.json")
+          '{ "driveLetterMapping": [ { "volumeName": "Temporary Storage 0", "driveLetter": "Z" } ] }' | Out-File $configPath
+
+          # Import Ec2Launch module to prepare to use helper functions.
+          Set-Variable modulePath -Option Constant -Scope Local -Value (Join-Path $ec2LaunchPath -ChildPath "Module\Ec2Launch.psd1")
+          Import-Module $modulePath
+
+          # Schedule for startup
+          Set-Variable scheduleName -Option Constant -Scope Local -Value "Disk Initialization"
+          Register-ScriptScheduler -ScriptPath $scriptPath -ScheduleName $scheduleName
+        }
     }
 
     # show file extensions, hidden items and disable item checkboxes

--- a/cloudygamer.psm1
+++ b/cloudygamer.psm1
@@ -145,22 +145,8 @@ workflow Install-CloudyGamer {
 
     # provision ephemeral storage as Z:
     if ($Using:IsAWS) {
-        Set-Variable ec2LaunchPath -Option Constant -Scope Local -Value (Join-Path $env:ProgramData -ChildPath "Amazon\EC2-Windows\Launch")
-        Set-Variable scriptPath -Option Constant -Scope Local -Value (Join-Path $ec2LaunchPath -ChildPath "Scripts\InitializeDisks.ps1")
-
-        if ($scriptPath) {
-          # Configure drive letter mapping
-          Set-Variable configPath -Option Constant -Scope Local -Value (Join-Path $ec2LaunchPath -ChildPath "Config\DriveLetterMappingConfig.json")
-          '{ "driveLetterMapping": [ { "volumeName": "Temporary Storage 0", "driveLetter": "Z" } ] }' | Out-File $configPath
-
-          # Import Ec2Launch module to prepare to use helper functions.
-          Set-Variable modulePath -Option Constant -Scope Local -Value (Join-Path $ec2LaunchPath -ChildPath "Module\Ec2Launch.psd1")
-          Import-Module $modulePath
-
-          # Schedule for startup
-          Set-Variable scheduleName -Option Constant -Scope Local -Value "Disk Initialization"
-          Register-ScriptScheduler -ScriptPath $scriptPath -ScheduleName $scheduleName
-        }
+        '{ "driveLetterMapping": [ { "volumeName": "Temporary Storage 0", "driveLetter": "Z" } ] }' > c:\ProgramData\Amazon\EC2-Windows\Launch\Config\DriveLetterMappingConfig.json
+        c:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeDisks.ps1 -Schedule
     }
 
     # show file extensions, hidden items and disable item checkboxes

--- a/cloudygamer.psm1
+++ b/cloudygamer.psm1
@@ -145,8 +145,8 @@ workflow Install-CloudyGamer {
 
     # provision ephemeral storage as Z:
     if ($Using:IsAWS) {
-        '{ "driveLetterMapping": [ { "volumeName": "Temporary Storage 0", "driveLetter": "Z" } ] }' > c:\ProgramData\Amazon\EC2-Windows\Launch\Config\DriveLetterMappingConfig.json
-        c:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeDisks.ps1 -Schedule
+      '{ "driveLetterMapping": [ { "volumeName": "Temporary Storage 0", "driveLetter": "Z" } ] }' > c:\ProgramData\Amazon\EC2-Windows\Launch\Config\DriveLetterMappingConfig.json
+      c:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeDisks.ps1 -Schedule
     }
 
     # show file extensions, hidden items and disable item checkboxes

--- a/cloudygamer.psm1
+++ b/cloudygamer.psm1
@@ -141,6 +141,10 @@ workflow Install-CloudyGamer {
     if ($Using:IsAWS) {
       Remove-Item "$home\Desktop\EC2 Feedback.website" -ErrorAction SilentlyContinue
       Remove-Item "$home\Desktop\EC2 Microsoft Windows Guide.website" -ErrorAction SilentlyContinue
+
+      # provision ephemeral storage as Z:
+      '{ "driveLetterMapping": [ { "volumeName": "Temporary Storage 0", "driveLetter": "Z" } ] }' > c:\ProgramData\Amazon\EC2-Windows\Launch\Config\DriveLetterMappingConfig.json
+      c:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeDisks.ps1 -Schedule
     }
 
     # show file extensions, hidden items and disable item checkboxes


### PR DESCRIPTION
Hiya @lg,
I've taken the jump from using the premade community ami to trying out the provisioning script in the repo. It works very well automagically, but it looks like it doesn't set the Z: mount.

It seems some config needs to be changed from the base Win 2016 image, and found this documented in the "Initialize Drives and Drive Letter Mappings" section of http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch.html

Not too well versed in powershell, but I took a stab at adding a few lines to do this for myself and thought might as well do a pull request if this is valuable.